### PR TITLE
Store and render authority name

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,8 @@
 var storeAnswers = function storeAnswers() {
+  $('form input[type="text"]').each(function() {
+    sessionStorage.setItem(this.name, this.value);
+  });
+
   $('form input[type="radio"]:checked').each(function() {
     sessionStorage.setItem(this.name, this.value);
   });

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ bodyclass: "home"
           <label class="form-label" for="authority-name">
             Authority Name
           </label>
-          <input class="form-control" id="authority-name" type="text" name="authority-name">
+          <input class="form-control" id="authority-name" type="text" name="authority-name" required>
         </fieldset>
       </div>
 

--- a/results.html
+++ b/results.html
@@ -28,6 +28,10 @@ bodyclass: "results-page"
       </thead>
       <tbody>
         <tr>
+          <th scope="row">Name</th>
+          <td class="numeric" data-question="authority-name">[unknown]</td>
+        </tr>
+        <tr>
           <th scope="row">Size</th>
           <td class="numeric" data-question="employees">5000+</td>
         </tr>


### PR DESCRIPTION
Just adds it to the Overview table for now, but we may want to give it
more weight.

<img width="689" alt="Screenshot 2019-04-12 at 13 46 50" src="https://user-images.githubusercontent.com/282788/56038279-733e0f00-5d29-11e9-87bd-c09aee2eb345.png">

Fixes #14 