### PR TITLE
Make 'see more' and other non-main path links de-emphasised

### DIFF
--- a/_sass/foi-self-assessment.scss
+++ b/_sass/foi-self-assessment.scss
@@ -124,3 +124,19 @@ body {
                     radial-gradient(8px 8px at 70% 50%, #e9e9e9 49%, rgba(255,0,0,0) 50%),
                     radial-gradient(8px 8px at 90% 50%, #e9e9e9 49%, rgba(255,0,0,0) 50%);
 }
+
+
+.deemphasised-link {
+    color: #666;
+    text-decoration: none;
+    &:active,
+    &:visited,
+    &:link {
+        color: #666;
+        text-decoration: none;
+    }
+    &:hover {
+        color: #2b8cc4;
+        text-decoration: underline;
+    }
+}

--- a/results.html
+++ b/results.html
@@ -45,7 +45,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">How scores are calculated</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">How scores are calculated</a></p>
   </div>
   <div class="column-one-third">
     <div class="results-radar-chart"></div>
@@ -93,7 +93,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">Edit your answers</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">Edit your answers</a></p>
     <table class="results-section-table">
       <thead>
         <tr>
@@ -116,7 +116,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">See more guides</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">See more guides</a></p>
     <table class="results-section-table">
       <thead>
         <tr>
@@ -135,7 +135,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">See more issues</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">See more issues</a></p>
 
 
     <h2 class="heading-medium results-section-heading">Process</h2>
@@ -174,7 +174,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">Edit your answers</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">Edit your answers</a></p>
     <table class="results-section-table">
       <thead>
         <tr>
@@ -197,7 +197,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">See more guides</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">See more guides</a></p>
     <table class="results-section-table">
       <thead>
         <tr>
@@ -216,7 +216,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">See more issues</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">See more issues</a></p>
 
 
     <h2 class="heading-medium results-section-heading">Technology</h2>
@@ -243,7 +243,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">Edit your answers</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">Edit your answers</a></p>
     <table class="results-section-table">
       <thead>
         <tr>
@@ -266,7 +266,7 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">See more guides</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">See more guides</a></p>
     <table class="results-section-table">
       <thead>
         <tr>
@@ -285,6 +285,6 @@ bodyclass: "results-page"
         </tr>
       </tbody>
     </table>
-    <p class="font-xsmall"><a href="#" class="not-implemented">See more issues</a></p>
+    <p class="font-xsmall"><a href="#" class="not-implemented deemphasised-link">See more issues</a></p>
   </div>
 </div>


### PR DESCRIPTION
![Screenshot 2019-04-15 at 12 14 44](https://user-images.githubusercontent.com/2292925/56128609-14220980-5f78-11e9-985b-56216b76ed4a.png)
